### PR TITLE
Bump DOMjudge to 8.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To run a Judgehost, use the `start-judgehost.sh` script.
   	-u, --domserver-baseurl: Baseurl of the DOMserver (default: 'https://dj.chipcie.ch.tudelft.nl/')
   	-p, --password: Password of the judgehosts in the domserver (leave empty for prompt) (no default)
   	-c, --container: Docker container to use as judgehost (default: 'ghcr.io/wisvch/domjudge-packaging/judgehost')
-  	-v, --version: Version of the container (default: '8.2.0')
+  	-v, --version: Version of the container (default: '8.2.1')
   ```
 
 You can run multiple judgehosts on one machine if desired.

--- a/domserver-spectator/docker-compose.yml
+++ b/domserver-spectator/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   domserver-spectator:
-    image: ghcr.io/wisvch/domjudge-packaging/domserver:8.2.0
+    image: ghcr.io/wisvch/domjudge-packaging/domserver:8.2.1
     ports:
       - "8082:80"
     depends_on:

--- a/domserver/docker-compose.yml
+++ b/domserver/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   domserver:
-    image: ghcr.io/wisvch/domjudge-packaging/domserver:8.2.0
+    image: ghcr.io/wisvch/domjudge-packaging/domserver:8.2.1
     ports:
       - "8080:80"
     depends_on:

--- a/start-judgehost.sh
+++ b/start-judgehost.sh
@@ -47,7 +47,7 @@ _arg_domserver_baseurl="https://dj.chipcie.ch.tudelft.nl/"
 _arg_password=
 _arg_hostname="judgedaemon"
 _arg_container="ghcr.io/wisvch/domjudge-packaging/judgehost"
-_arg_version="8.2.0"
+_arg_version="8.2.1"
 _arg_detach="off"
 
 

--- a/start-judgehosts-gui.sh
+++ b/start-judgehosts-gui.sh
@@ -13,7 +13,7 @@ values=( $(yad --form --center --width=600 --title="Start Judgehosts" --separato
 	--field="Container" \
 	    'ghcr.io/wisvch/domjudge-packaging/judgehost' \
 	--field="Version" \
-	    '8.2.0' \
+	    '8.2.1' \
 	    ) )
 
 if [ $? -eq 0 ]; then


### PR DESCRIPTION
I've updated the DOMjudge version in other places as well, I was already wondering why my local judgehosts weren't automatically pulling the latest version :stuck_out_tongue: 