### PR TITLE
Persistent storage for DOMjudge

### DIFF
--- a/domserver-spectator/docker-compose.yml
+++ b/domserver-spectator/docker-compose.yml
@@ -24,6 +24,8 @@ services:
     env_file:
         - domserver-spectator.env
     command: --max-connections=1000
+    volumes:
+      - ${PWD}/mysql:/var/lib/mysql
 
   phpmyadmin-spectator:
     image: phpmyadmin/phpmyadmin

--- a/domserver/docker-compose.yml
+++ b/domserver/docker-compose.yml
@@ -19,6 +19,8 @@ services:
     env_file:
         - domserver.env
     command: --max-connections=1000
+    volumes:
+      - ${PWD}/mariadb:/var/lib/mysql
 
   phpmyadmin:
     image: phpmyadmin/phpmyadmin

--- a/domserver/docker-compose.yml
+++ b/domserver/docker-compose.yml
@@ -20,7 +20,7 @@ services:
         - domserver.env
     command: --max-connections=1000
     volumes:
-      - ${PWD}/mariadb:/var/lib/mysql
+      - ${PWD}/mysql:/var/lib/mysql
 
   phpmyadmin:
     image: phpmyadmin/phpmyadmin


### PR DESCRIPTION
It would be good to have persistent storage for DOMjudge. Unsure what exactly needs persistent storage, added the database for now.